### PR TITLE
Deploy from main instead of master

### DIFF
--- a/.github/workflows/deploy-to-gh-pages.yaml
+++ b/.github/workflows/deploy-to-gh-pages.yaml
@@ -3,7 +3,7 @@ name: github pages
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   deploy:


### PR DESCRIPTION
Since I renamed `master` to `main`, the deploy action no longer works. This PR fixes that.